### PR TITLE
[fix] fail html parsing gracefully

### DIFF
--- a/.changeset/quick-keys-appear.md
+++ b/.changeset/quick-keys-appear.md
@@ -1,0 +1,5 @@
+---
+"@m2d/html": patch
+---
+
+Prevent hard failure when parsing content with invalid html tags

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -511,7 +511,12 @@ const preprocess = (pNode: Parent, isRoot = true) => {
       // ending tag
       if (tag[0] === "/") {
         const hNode = htmlNodeStack.shift();
-        if (!hNode) throw new Error(`Invalid HTML: ${value}`);
+        if (!hNode) {
+          console.warn(
+            `[HTML Plugin] Invalid HTML detected: closing tag without matching opening tag: ${value}`,
+          );
+          continue;
+        }
         processInlineNode(hNode);
         (htmlNodeStack[0]?.children ?? children).push(hNode);
       } else {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "pnpm": {
     "overrides": {
-      "cross-spawn@<6.0.6": ">=6.0.6",
-      "parse5": "^7.1.2"
+      "cross-spawn@<6.0.6": ">=6.0.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "pnpm": {
     "overrides": {
-      "cross-spawn@<6.0.6": ">=6.0.6"
+      "cross-spawn@<6.0.6": ">=6.0.6",
+      "parse5": "^7.1.2"
     }
   }
 }

--- a/sample.md
+++ b/sample.md
@@ -37,6 +37,8 @@ Indentation and formatting etc. here should be preserved.
       Hmmm...
 </pre>
 
+Invalid HTML will be ignored </missing-opening-tag>
+
 #### Styles
 
 <p style="color: red; border: 1px solid gray; text-align: center; font-weight: bold; font-style: oblique; text-decoration: underline; text-transform: uppercase;">My <s>crazily</s> styled text here. <sup>super</sup> and <sub>sub</sub> </p>


### PR DESCRIPTION
**Problem description**
Markdown generated from LLMs may, from time to time, contain invalid HTML or tags that either are not closed or opened correctly.

**Expected behavior**
Exporting markdown to docx should not crash/fail if invalid html is detected

**Solution**
Ignore invalid HTML tags and log a warning in the console.